### PR TITLE
Feat/add english readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > **TL;DR:** PromptX是一个系统性的， 工程化的提示词管理框架，它提供了结构化、模块化的方式来构建和管理AI提示词。
 
+**中文** | [English](README_EN.md) | [Issues](https://github.com/Deepractice/PromptX/issues)
+
 ## 快速开始
 
 ### 安装
@@ -65,7 +67,7 @@ AI将自动按照PromptX协议加载角色、思维模式、执行框架和记�
 
 ## 提示词增强
 
-使用PromptX可以让您的 AI 助手更加智能，更加贴心，PromptX 将从一下几个维度强化 AI：
+使用PromptX可以让您的 AI 助手更加智能，更加贴心，PromptX 将从以下几个维度强化 AI：
 
 ### 思维模式 (Thought)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,166 @@
+# PromptX
+
+> **TL;DR:** PromptX is a systematic, enterprise-grade prompt engineering framework that provides structured and modular approaches for building and managing AI prompts.
+
+[Chinese](README.md) | **English** | [Issues](https://github.com/Deepractice/PromptX/issues)
+
+## 🚀 Why PromptX?
+
+### The Challenge
+- **Scattered Prompt Management**: Prompts spread across different projects without standardization
+- **Lack of Engineering Practices**: No systematic approach to prompt development and optimization  
+- **Limited Reusability**: Difficulty in sharing and reusing prompt components across teams
+- **No Memory & Learning**: AI assistants can't learn from previous interactions
+
+### The Solution
+PromptX introduces **DPML (Deepractice Prompt Markup Language)** - a structured framework for prompt engineering with:
+
+- 🧠 **Cognitive Patterns**: Multi-dimensional thinking capabilities (exploration, reasoning, planning, challenge)
+- ⚡ **Execution Framework**: Standardized workflows and quality assurance
+- 💾 **Memory System**: Intelligent context retention and learning capabilities  
+- 🎭 **Role-based Architecture**: Pre-built professional roles with specialized expertise
+- 🔧 **Modular Design**: Reusable components for rapid development
+
+## 📦 Quick Start
+
+### Prerequisites
+
+- Node.js (>= 14.0.0)
+
+### Installation
+
+PromptX is a prompt framework that can be integrated into your project in the following way:
+
+#### Clone and Copy to Your Project
+
+```bash
+# Clone PromptX repository
+git clone https://github.com/Deepractice/PromptX.git
+
+# Copy PromptX directory to your project
+cp -r PromptX /path/to/your/project/
+```
+
+### Basic Usage
+
+Follow these steps to get started with PromptX:
+
+#### Step 1: Open bootstrap.md File
+```bash
+# View the role bootstrap file
+cat PromptX/bootstrap.md
+```
+
+#### Step 2: Configure Role Reference
+Modify the role reference in bootstrap.md, for example:
+```markdown
+@file://PromptX/domain/scrum/role/product-owner.role.md
+```
+
+#### Step 3: Set as System Prompt
+Copy the modified bootstrap.md content to your AI system's system prompt.
+
+You can use it with tools like Cursor Rules or directly paste the bootstrap content into your AI chat interface.
+
+<img src="assets/demo2.jpg" alt="System Prompt Configuration Demo" width="500">
+
+*Note: Screenshots show Chinese interface*
+
+#### Step 4: Send Action Command
+Send the following command to your AI:
+```
+Action
+```
+
+The AI will automatically load roles, cognitive patterns, execution frameworks, and memory systems according to the PromptX protocol.
+
+### Demo
+
+<img src="assets/demo.gif" alt="PromptX Usage Demo" width="600">
+
+*Note: Demo shows Chinese interface*
+
+## 🧠 AI Enhancement Capabilities
+
+PromptX enhances your AI assistant across multiple dimensions:
+
+### Cognitive Patterns (Thought)
+
+Provides structured thinking capabilities for AI:
+
+- **Multi-perspective Analysis** - Comprehensive problem analysis from exploration, reasoning, planning, and challenge dimensions
+- **Logical Rigor** - Establishes clear causal relationships and reasoning chains
+- **Decision Support** - Develops actionable plans and execution paths  
+- **Risk Identification** - Proactively identifies potential issues and improvement opportunities
+
+### Execution Framework (Execution)
+
+Empowers AI with standardized behavioral capabilities:
+
+- **Standardized Execution** - Completes tasks following clear processes and procedures
+- **Quality Assurance** - Adheres to industry best practices and quality standards
+- **Boundary Awareness** - Clear understanding of capabilities and limitations
+- **Continuous Improvement** - Optimizes execution based on feedback
+
+### Memory System (Memory)
+
+Enables AI learning and memory capabilities:
+
+- **Intelligent Memory** - Automatically identifies and saves important information
+- **Context Awareness** - Provides personalized services based on historical interactions
+- **Knowledge Accumulation** - Continuously learns and improves knowledge base
+- **Experience Transfer** - Applies successful experiences to new scenarios
+
+The prompt system includes a built-in memory mode with memory evaluation (AI autonomously assesses what content is worth remembering), memory storage (stored by default in .memory files in the project root directory), and recall (AI automatically recalls existing memory content at startup).
+
+During usage, users can ask AI to remember certain information, such as "Remember this experience, we'll use it next time." AI will also autonomously evaluate what content is worth remembering.
+
+<img src="assets/demo3.jpg" alt="AI Memory Example" width="600">
+
+*Note: Screenshot shows Chinese interface*
+
+## 🎭 Built-in Roles
+
+PromptX framework includes multiple professional roles ready to use:
+
+| Category | Role Name | File Path | Key Capabilities |
+|----------|-----------|-----------|------------------|
+| Basic | Assistant | `@file://PromptX/domain/assistant/assistant.role.md` | Basic thinking and memory capabilities, suitable for general conversation and information processing |
+| Scrum Agile | Product Owner | `@file://PromptX/domain/scrum/role/product-owner.role.md` | Product planning, requirement management, priority decision-making, user-oriented thinking, data-driven decisions |
+| DPML Development | Prompt Developer | `@file://PromptX/domain/prompt/prompt-developer.role.md` | Exploratory, systematic and critical thinking, DPML development standards, prompt engineering best practices |
+| Content Creation | Video Copywriter | `@file://PromptX/domain/copywriter/video-copywriter.role.md` | Creative, narrative and marketing thinking, video content creation, copywriting standards, communication optimization |
+
+## 🛠️ Custom Roles
+
+You can easily create custom roles using PromptX:
+
+1. Reference the prompt developer role in bootstrap.md:
+   ```
+   @file://PromptX/domain/prompt/prompt-developer.role.md
+   ```
+2. Describe your new role requirements to the prompt developer AI
+3. AI will automatically generate a complete role definition file
+4. Save the generated role file and reference it in bootstrap.md
+
+This approach makes prompt development AI-assisted!
+
+## 🌐 Resources
+
+- [Deepractice Official Website](https://www.deepracticex.com/) - Deepractice
+- [DPML Project](https://github.com/Deepractice/dpml) - Deepractice Prompt Markup Language
+
+### Community & Support
+
+- 🐛 [Report Issues](https://github.com/Deepractice/PromptX/issues)
+- 💬 [Join Discussions](https://github.com/Deepractice/PromptX/discussions)
+- ⭐ [Star this Project](https://github.com/Deepractice/PromptX)
+
+## 📄 License
+
+MIT
+
+---
+
+**Need industry-specific roles but don't know how to develop them?** 
+
+Feel free to [open an issue](https://github.com/Deepractice/PromptX/issues) with your requirements! 


### PR DESCRIPTION
## 🌍 Add English README for International Users

### 变更类型
- [x] 新功能 (feature)  
- [x] 文档更新 (docs)

### 变更描述
为PromptX项目添加专业的英文版README，支持国际化推广：

- ✨ 新增 `README_EN.md` 英文版文档
- 🔗 添加中英文双向语言切换导航  
- 🎯 采用"Enterprise-Grade Prompt Engineering Framework"定位
- 🌐 用GitHub Issues替代微信群，适配国际用户
- 🐛 修正中文版README错别字

### 影响范围
- **影响模块**: 文档系统
- **向后兼容性**: ✅ 完全兼容，仅新增文件
- **性能影响**: 无

### 检查清单
- [x] 英文翻译准确且专业
- [x] 语言切换链接有效
- [x] 符合国际开源项目标准
- [x] 保持中文版为主，英文版为补充

### 预览
- 📖 [English README Preview](../blob/feat/add-english-readme/README_EN.md)
- 🔄 语言切换功能正常