### PR TITLE
修复中文路径URL编码问题

### DIFF
--- a/src/lib/core/pouch/commands/InitCommand.js
+++ b/src/lib/core/pouch/commands/InitCommand.js
@@ -45,8 +45,9 @@ class InitCommand extends BasePouchCommand {
     let projectPath
     
     if (workingDirectory) {
-      // AI提供了工作目录，使用AI提供的路径
-      projectPath = path.resolve(workingDirectory)
+      // AI提供了工作目录，先解码中文路径，然后使用
+      const decodedWorkingDirectory = decodeURIComponent(workingDirectory)
+      projectPath = path.resolve(decodedWorkingDirectory)
       
       // 验证AI提供的路径是否有效
       if (!await this.currentProjectManager.validateProjectPath(projectPath)) {
@@ -153,7 +154,7 @@ ${registryStats.message}
       if (registryData.size === 0) {
         return {
           message: `✅ 项目资源目录已创建，注册表已初始化
-   📂 目录: ${path.relative(process.cwd(), domainDir)}
+   📂 目录: ${path.relative(process.cwd(), resourceDir)}
    💾 注册表: ${path.relative(process.cwd(), registryPath)}
    💡 现在可以在 domain 目录下创建角色资源了`,
           totalResources: 0


### PR DESCRIPTION
## 🐛 问题描述
修复MCP传入中文路径时被URL编码导致路径验证失败的问题。

## 🔧 解决方案
- 在 `InitCommand.js` 中添加 `decodeURIComponent()` 处理URL编码的路径
- 支持类似 `/home/azu/%E6%A1%8C%E9%9D%A2/PromptX` 的编码路径

## ✅ 测试验证
- [x] 本地测试通过
- [x] 支持中文路径解码
- [x] 向后兼容非编码路径

## 📋 相关Issue
解决在中文系统环境下MCP无法正确识别工作目录的问题。