### PR TITLE
chore: prepare release to test [auto]

### DIFF
--- a/.github/release-config.yml
+++ b/.github/release-config.yml
@@ -1,0 +1,52 @@
+# 版本发布配置文件
+# 定义哪些路径的修改不应该触发版本发布
+
+skip_release_paths:
+  # 文档相关
+  - "README*.md"
+  - "CHANGELOG.md"
+  - "CONTRIBUTING.md"
+  - "LICENSE*"
+  - "docs/**"
+  - "assets/**"
+  - "examples/**"
+  
+  # 开发配置
+  - ".github/**"
+  - ".vscode/**"
+  - ".gitignore"
+  - ".npmignore"
+  - ".editorconfig"
+  - ".eslintrc*"
+  - ".prettierrc*"
+  - ".babelrc*"
+  - "*.config.js"
+  - "*.config.ts"
+  
+  # 测试相关（但不包括测试代码本身）
+  - "coverage/**"
+  - ".nyc_output/**"
+  
+# 需要发版的路径（即使在 skip_release_paths 中）
+require_release_paths:
+  - "package.json"
+  - "src/**"
+  - "lib/**"
+  - "index.js"
+  - "index.ts"
+  - "prompt/**/*.md"  # 提示词文件需要发版
+  
+# PR 标题前缀到标签的映射
+pr_title_labels:
+  "docs:": ["documentation", "skip-release"]
+  "doc:": ["documentation", "skip-release"]
+  "chore:": ["chore"]
+  "ci:": ["ci/cd", "skip-release"]
+  "workflow:": ["ci/cd", "skip-release"]
+  "style:": ["style", "skip-release"]
+  "refactor:": ["refactor"]
+  "test:": ["test"]
+  "feat:": ["feature"]
+  "fix:": ["bugfix"]
+  "perf:": ["performance"]
+  "build:": ["build"]

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -31,6 +31,17 @@ jobs:
             const changedPaths = files.map(f => f.filename);
             console.log('Changed files:', changedPaths);
             
+            // 添加详细的文件统计
+            const fileStats = {
+              total: changedPaths.length,
+              docs: 0,
+              config: 0,
+              core: 0,
+              prompt: 0,
+              test: 0,
+              other: 0
+            };
+            
             // 检查是否只包含文档和配置文件
             const docsAndConfigPaths = [
               /^README.*\.md$/,
@@ -81,18 +92,38 @@ jobs:
             const result = ${{ steps.changed-files.outputs.result }};
             const labels = [];
             
-            if (result.isDocsOrConfig && !result.hasPromptFiles) {
-              labels.push('documentation');
-              labels.push('skip-release');
+            // 处理不同类型的变更组合
+            if (result.hasCoreChanges) {
+              labels.push('core-changes');
+              // 有核心代码变更时，需要发版
             }
             
             if (result.hasPromptFiles) {
               labels.push('prompt-update');
-              // 提示词更新可能需要发版，不添加 skip-release
+              // 提示词更新需要发版
             }
             
-            if (result.hasCoreChanges) {
-              labels.push('core-changes');
+            if (result.isDocsOrConfig && !result.hasPromptFiles) {
+              // 纯文档/配置修改
+              labels.push('documentation');
+              labels.push('skip-release');
+            } else if (!result.hasCoreChanges && !result.hasPromptFiles) {
+              // 既不是纯文档，也没有核心代码和提示词变更
+              // 可能是测试文件等，根据具体情况决定
+              const hasTestChanges = changedPaths.some(path => 
+                path.includes('test/') || path.includes('__tests__/') || 
+                path.endsWith('.test.js') || path.endsWith('.spec.js')
+              );
+              if (hasTestChanges) {
+                labels.push('test');
+                // 测试文件修改通常不需要发版，除非同时有代码修改
+              }
+            }
+            
+            // 添加混合变更标签
+            if (result.hasCoreChanges && result.isDocsOrConfig) {
+              labels.push('mixed-changes');
+              // 混合变更时，以代码变更为准，需要发版
             }
             
             // 根据 PR 标题添加标签
@@ -122,4 +153,29 @@ jobs:
                 labels: labels
               });
               console.log(`Applied labels: ${labels.join(', ')}`);
+            }
+            
+            // 对混合变更的 PR 添加说明评论
+            if (result.hasCoreChanges && (result.isDocsOrConfig || labels.includes('documentation'))) {
+              const skipRelease = labels.includes('skip-release');
+              const comment = `## 📊 变更分析报告
+              
+本 PR 包含了**混合类型**的变更：
+- ✅ 核心代码变更
+- 📚 文档/配置变更
+
+**版本发布决策**: ${skipRelease ? '⏭️ 跳过版本发布' : '🚀 将触发版本发布'}
+
+> 💡 提示：如果您只想更新文档而不发版，请将代码和文档变更分开到不同的 PR 中。`;
+              
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: comment
+                });
+              } catch (error) {
+                console.log('Failed to create comment:', error);
+              }
             }

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,0 +1,125 @@
+name: Auto Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Get changed files
+        id: changed-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            
+            const changedPaths = files.map(f => f.filename);
+            console.log('Changed files:', changedPaths);
+            
+            // 检查是否只包含文档和配置文件
+            const docsAndConfigPaths = [
+              /^README.*\.md$/,
+              /^CHANGELOG\.md$/,
+              /^CONTRIBUTING\.md$/,
+              /^LICENSE/,
+              /^docs\//,
+              /^assets\//,
+              /^\.github\//,
+              /^examples\//,
+              /^\.gitignore$/,
+              /^\.npmignore$/,
+              /^\.editorconfig$/,
+              /^\.(eslintrc|prettierrc|babelrc)/
+            ];
+            
+            const isDocsOrConfig = changedPaths.every(path => 
+              docsAndConfigPaths.some(pattern => pattern.test(path))
+            );
+            
+            // 检查是否包含提示词文件（在 prompt 目录下的 .md 文件）
+            const hasPromptFiles = changedPaths.some(path => 
+              path.startsWith('prompt/') && path.endsWith('.md')
+            );
+            
+            // 检查是否包含核心代码变更
+            const hasCoreChanges = changedPaths.some(path => 
+              path.endsWith('.js') || 
+              path.endsWith('.ts') || 
+              path.endsWith('.json') && !path.includes('.github/') ||
+              path.startsWith('src/') ||
+              path.startsWith('lib/') ||
+              path === 'package.json'
+            );
+            
+            return {
+              isDocsOrConfig,
+              hasPromptFiles,
+              hasCoreChanges,
+              fileCount: changedPaths.length
+            };
+            
+      - name: Apply labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT || github.token }}
+          script: |
+            const result = ${{ steps.changed-files.outputs.result }};
+            const labels = [];
+            
+            if (result.isDocsOrConfig && !result.hasPromptFiles) {
+              labels.push('documentation');
+              labels.push('skip-release');
+            }
+            
+            if (result.hasPromptFiles) {
+              labels.push('prompt-update');
+              // 提示词更新可能需要发版，不添加 skip-release
+            }
+            
+            if (result.hasCoreChanges) {
+              labels.push('core-changes');
+            }
+            
+            // 根据 PR 标题添加标签
+            const title = context.payload.pull_request.title.toLowerCase();
+            if (title.includes('chore:') || title.includes('chore(')) {
+              labels.push('chore');
+              if (!result.hasCoreChanges) {
+                labels.push('skip-release');
+              }
+            }
+            
+            if (title.includes('docs:') || title.includes('doc:')) {
+              labels.push('documentation');
+              labels.push('skip-release');
+            }
+            
+            if (title.includes('ci:') || title.includes('workflow:')) {
+              labels.push('ci/cd');
+              labels.push('skip-release');
+            }
+            
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+              console.log(`Applied labels: ${labels.join(', ')}`);
+            }

--- a/.github/workflows/auto-version-on-merge.yml
+++ b/.github/workflows/auto-version-on-merge.yml
@@ -17,13 +17,28 @@ jobs:
       pull-requests: write
       
     steps:
+      - name: Check PR labels
+        id: labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const skipRelease = labels.includes('skip-release') || 
+                               labels.includes('documentation') || 
+                               labels.includes('chore');
+            console.log(`PR Labels: ${labels.join(', ')}`);
+            console.log(`Skip Release: ${skipRelease}`);
+            return { skipRelease };
+            
       - name: Checkout repository
+        if: steps.labels.outputs.result != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT || github.token }}
           
       - name: Check for release marker
+        if: steps.labels.outputs.result != 'true'
         id: check
         run: |
           if [ -f ".release-pending.json" ]; then

--- a/.github/workflows/docs-management.yml
+++ b/.github/workflows/docs-management.yml
@@ -1,0 +1,57 @@
+name: Documentation Management
+
+on:
+  push:
+    branches:
+      - 'docs/**'  # 所有 docs/ 开头的分支
+      - 'doc/**'   # 或 doc/ 开头的分支
+    paths:
+      - 'README*.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE*'
+      - 'docs/**'
+      - 'assets/**'
+      - '.github/**'
+      - 'examples/**'
+      
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'README*.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE*'
+      - 'docs/**'
+      - 'assets/**'
+      - '.github/**'
+      - 'examples/**'
+
+jobs:
+  docs-check:
+    name: Documentation Check
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      - name: Check markdown files
+        run: |
+          echo "📚 Documentation changes detected"
+          echo "This PR contains only documentation changes and will not trigger version release"
+          
+      - name: Label PR as documentation
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT || github.token }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['documentation', 'skip-release']
+            });

--- a/.release-pending.json
+++ b/.release-pending.json
@@ -1,0 +1,6 @@
+{
+  "release_type": "auto",
+  "target_branch": "test",
+  "triggered_by": "deepracticexs",
+  "triggered_at": "2025-07-10T03:24:41Z"
+}


### PR DESCRIPTION
## 🚀 版本发布准备
  
  此PR将在合并时自动执行版本升级和发布。
  
  ### 📋 发布信息
  - **目标分支**: test
  - **发布类型**: auto
  - **触发者**: @deepracticexs
  
  ### ⏳ 等待预览
  GitHub Actions 将在几秒内生成版本变更预览...
  
  ### ✅ 合并后将自动执行
  1. 根据commit历史计算版本号
  2. 生成CHANGELOG.md  
  3. 提交版本变更
  4. 触发对应的发布流程
  
  ### 🔄 发布流程
  - 合并到 `test` → 触发 `npm-alpha-release.yml` → 发布 `alpha` 版本
  - 合并到 `staging` → 触发 `npm-beta-release.yml` → 发布 `beta` 版本
  - 合并到 `main` → 触发 `npm-latest-release.yml` → 发布正式版本
  
  > ⚠️ **注意**: 请等待版本预览生成后再审核此PR