### PR TITLE
fix: 暂时禁用 promptx_think 工具避免功能重叠

### DIFF
--- a/src/lib/mcp/toolDefinitions.js
+++ b/src/lib/mcp/toolDefinitions.js
@@ -116,7 +116,11 @@ function loadToolDefinitions() {
   const definitions = [];
   
   // 读取所有 JS 文件
-  const files = fs.readdirSync(definitionsDir).filter(file => file.endsWith('.js'));
+  // 暂时禁用 promptx_think 工具，避免与 promptx_action 功能重叠造成用户困惑
+  // Issue #201: 保留代码，仅禁用注册，便于后续重新启用或重新设计
+  const files = fs.readdirSync(definitionsDir)
+    .filter(file => file.endsWith('.js'))
+    .filter(file => file !== 'promptx_think.js'); // 暂时禁用 think 工具
   
   for (const file of files) {
     const filePath = path.join(definitionsDir, file);


### PR DESCRIPTION
## Summary
- 暂时禁用 `promptx_think` 工具的注册，保留所有代码
- 通过在 `loadToolDefinitions` 中过滤掉 `promptx_think.js` 实现
- 最小化改动，便于后续重新启用或重新设计

## 问题描述
根据 Issue #201，`promptx_think` 和 `promptx_action` 功能重叠，造成用户选择困难：
- 两个工具职责边界模糊
- think 没有提供 action 无法实现的独特价值
- think 使用复杂（需要构造 JSON），action 使用简单（只需角色 ID）

## 解决方案
采用最保守的方案：
1. 保留所有代码文件不变
2. 仅在工具注册时过滤掉 `promptx_think.js`
3. 添加清晰的注释说明禁用原因
4. 便于后续根据用户反馈重新设计或启用

## 改动内容
- 修改 `src/lib/mcp/toolDefinitions.js` 的 `loadToolDefinitions` 函数
- 添加过滤逻辑：`.filter(file => file \!== 'promptx_think.js')`
- 添加注释说明禁用原因和 Issue 编号

## Test plan
- [x] 代码改动完成
- [x] 添加注释说明
- [ ] 重启 MCP 服务验证工具列表
- [ ] 确认 promptx_think 不再出现
- [ ] 确认 promptx_action 正常工作

Closes #201

🤖 Generated with [Claude Code](https://claude.ai/code)