### PR TITLE
fix: 验证自动标签和发布控制 #219

### DIFF
--- a/test-fix-219.md
+++ b/test-fix-219.md
@@ -1,0 +1,18 @@
+# Test Fix Branch for Issue #219
+
+This is a test file to verify the fix branch workflow:
+
+1. Branch name: `fix/#219-test-workflow`
+2. Issue: #219
+3. Expected labels:
+   - `type: fix` (from branch-validator)
+   - `changeset/patch` (from auto-labeler)
+   - `merge/squash` (from auto-labeler)
+   - `publish/dev` (from auto-labeler, if PR to develop)
+
+## Testing Points
+
+- [ ] Branch validation passes
+- [ ] Auto-labeler adds correct labels
+- [ ] NPM publisher only runs with publish label
+- [ ] Changeset creation works correctly


### PR DESCRIPTION
## 测试修复后的工作流

这个 PR 用于验证：
1. ✅ **自动标签功能** - auto-labeler 应该自动添加正确的标签
2. ✅ **发布控制** - NPM Publisher 只在有 publish 标签时触发

### 预期自动添加的标签：
- `type: fix` ← branch-validator
- `changeset/patch` ← auto-labeler  
- `merge/squash` ← auto-labeler
- `publish/dev` ← auto-labeler

### 修复的问题：
- NPM Publisher 现在监听 PR closed 事件而不是 push
- 必须有 `publish/*` 标签才会触发发布

Fixes #219