### PR TITLE
refactor: 实现VM层文件系统边界控制 (#243)

### DIFF
--- a/.promptx/resource/tool/boundary-test/boundary-test.manual.md
+++ b/.promptx/resource/tool/boundary-test/boundary-test.manual.md
@@ -1,0 +1,130 @@
+# Boundary Test Tool Manual
+
+<manual>
+<identity>
+## 工具名称
+@tool://boundary-test
+
+## 简介
+专门用于测试ToolSandbox文件系统边界控制的安全测试工具
+</identity>
+
+<purpose>
+⚠️ **AI重要提醒**: 这是一个安全测试工具，用于验证沙箱的文件系统隔离是否正确实现。
+
+## 核心问题定义
+验证ToolSandbox是否正确实现了文件系统边界控制，防止工具逃逸沙箱访问系统文件。
+
+## 价值主张
+- 🎯 **解决什么痛点**：确保工具运行在安全隔离的环境中
+- 🚀 **带来什么价值**：防止恶意或有缺陷的工具危害系统安全
+- 🌟 **独特优势**：全面测试各种逃逸场景
+
+## 应用边界
+- ✅ **适用场景**：测试SandboxIsolationManager的安全性
+- ❌ **不适用场景**：生产环境的实际文件操作
+</purpose>
+
+<usage>
+## 使用时机
+- 修改SandboxIsolationManager后进行安全验证
+- 定期安全审计
+- 新工具上线前的安全测试
+
+## 操作步骤
+1. **准备阶段**：确保在ToolSandbox环境中运行
+2. **执行阶段**：选择测试类型执行
+3. **验证阶段**：检查测试结果，确保所有安全测试通过
+
+## 测试类型说明
+- **normal**: 测试正常的文件访问（应该成功）
+- **relative-escape**: 测试相对路径越权（应该被拦截）
+- **absolute-escape**: 测试绝对路径越权（应该被拦截）
+- **dangerous-ops**: 测试危险操作（应该被阻止）
+
+## 最佳实践
+- 🎯 **完整测试**：依次运行所有测试类型
+- ⚠️ **结果分析**：仔细检查每个失败的测试
+- 🔧 **故障排除**：如果安全测试失败，立即修复漏洞
+
+## 注意事项
+- 这是一个安全测试工具，不应在生产环境使用
+- 测试结果中的"success"表示安全控制是否生效
+- 所有越权尝试都应该被成功拦截
+</usage>
+
+<parameter>
+## 必需参数
+| 参数名 | 类型 | 描述 | 示例 |
+|--------|------|------|------|
+| testType | string | 测试类型 | "normal", "relative-escape", "absolute-escape", "dangerous-ops" |
+
+## 参数约束
+- **testType**: 必须是以下值之一
+  - `normal`: 正常文件访问测试
+  - `relative-escape`: 相对路径越权测试
+  - `absolute-escape`: 绝对路径越权测试
+  - `dangerous-ops`: 危险操作测试
+
+## 参数示例
+```json
+{
+  "testType": "relative-escape"
+}
+```
+</parameter>
+
+<outcome>
+## 成功返回格式
+```json
+{
+  "success": true,
+  "testType": "relative-escape",
+  "results": [
+    {
+      "category": "Relative Path Escape",
+      "tests": [
+        {
+          "test": "Access parent directory with ../..",
+          "success": true,
+          "message": "Correctly blocked: [SandboxFS] File access denied"
+        }
+      ],
+      "passed": 3,
+      "total": 3
+    }
+  ],
+  "summary": {
+    "status": "✅ ALL TESTS PASSED",
+    "totalTests": 3,
+    "passed": 3,
+    "failed": 0,
+    "passRate": "100.0%",
+    "security": "SECURE"
+  }
+}
+```
+
+## 错误处理格式
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid test type"
+  }
+}
+```
+
+## 结果解读指南
+- **success: true + security: SECURE**: 沙箱安全控制正常
+- **success: true + security: VULNERABLE**: 存在安全漏洞，需要立即修复
+- **passed < total**: 部分测试失败，检查具体失败项
+- **message中包含"SECURITY BREACH"**: 严重安全问题
+
+## 后续动作建议
+- ✅ 所有测试通过：沙箱安全，可以继续使用
+- ❌ 有测试失败：立即检查SandboxIsolationManager实现
+- 🔍 调试建议：查看具体失败的测试项，定位问题代码
+</outcome>
+</manual>

--- a/.promptx/resource/tool/boundary-test/boundary-test.tool.js
+++ b/.promptx/resource/tool/boundary-test/boundary-test.tool.js
@@ -1,0 +1,388 @@
+/**
+ * Boundary Test Tool
+ * 
+ * 用于测试ToolSandbox的文件系统边界控制
+ * 验证VM层透明拦截是否正确实现
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = {
+  /**
+   * 工具依赖
+   */
+  getDependencies() {
+    return {};  // 不需要外部依赖
+  },
+
+  /**
+   * 工具元信息
+   */
+  getMetadata() {
+    return {
+      name: 'boundary-test',
+      description: '测试ToolSandbox文件系统边界控制',
+      version: '1.0.0',
+      category: 'testing',
+      author: '鲁班',
+      tags: ['test', 'security', 'sandbox'],
+      manual: '@manual://boundary-test'
+    };
+  },
+
+  /**
+   * 参数Schema
+   */
+  getSchema() {
+    return {
+      type: 'object',
+      properties: {
+        testType: {
+          type: 'string',
+          enum: ['normal', 'relative-escape', 'absolute-escape', 'dangerous-ops'],
+          description: '测试类型'
+        }
+      },
+      required: ['testType']
+    };
+  },
+
+  /**
+   * 参数验证
+   */
+  validate(params) {
+    const validTypes = ['normal', 'relative-escape', 'absolute-escape', 'dangerous-ops'];
+    if (!validTypes.includes(params.testType)) {
+      return {
+        valid: false,
+        errors: [`Invalid test type: ${params.testType}`]
+      };
+    }
+    return { valid: true, errors: [] };
+  },
+
+  /**
+   * 执行测试
+   */
+  async execute(params) {
+    const results = [];
+    
+    switch (params.testType) {
+      case 'normal':
+        // 测试正常的文件访问（应该成功）
+        results.push(await this.testNormalAccess());
+        break;
+        
+      case 'relative-escape':
+        // 测试相对路径越权（应该被拦截）
+        results.push(await this.testRelativeEscape());
+        break;
+        
+      case 'absolute-escape':
+        // 测试绝对路径越权（应该被拦截）
+        results.push(await this.testAbsoluteEscape());
+        break;
+        
+      case 'dangerous-ops':
+        // 测试危险操作（应该被阻止）
+        results.push(await this.testDangerousOperations());
+        break;
+    }
+    
+    return {
+      success: true,
+      testType: params.testType,
+      results: results,
+      summary: this.generateSummary(results)
+    };
+  },
+
+  /**
+   * 测试正常文件访问
+   */
+  async testNormalAccess() {
+    const tests = [];
+    
+    // 测试1: 读取当前目录文件
+    try {
+      const testFile = path.join('.', 'test.txt');
+      fs.writeFileSync(testFile, 'Hello from boundary test');
+      const content = fs.readFileSync(testFile, 'utf-8');
+      tests.push({
+        test: 'Write and read file in working directory',
+        path: testFile,
+        success: content === 'Hello from boundary test',
+        message: 'Normal file access works correctly'
+      });
+      fs.unlinkSync(testFile);
+    } catch (error) {
+      tests.push({
+        test: 'Write and read file in working directory',
+        success: false,
+        error: error.message
+      });
+    }
+    
+    // 测试2: 创建子目录
+    try {
+      const subDir = path.join('.', 'test-subdir');
+      fs.mkdirSync(subDir, { recursive: true });
+      const exists = fs.existsSync(subDir);
+      tests.push({
+        test: 'Create subdirectory',
+        path: subDir,
+        success: exists,
+        message: 'Subdirectory creation works'
+      });
+      fs.rmdirSync(subDir);
+    } catch (error) {
+      tests.push({
+        test: 'Create subdirectory',
+        success: false,
+        error: error.message
+      });
+    }
+    
+    return {
+      category: 'Normal Access',
+      tests: tests,
+      passed: tests.filter(t => t.success).length,
+      total: tests.length
+    };
+  },
+
+  /**
+   * 测试相对路径越权
+   */
+  async testRelativeEscape() {
+    const tests = [];
+    
+    // 测试1: 尝试访问父目录
+    try {
+      const escapePath = path.join('..', '..', 'etc', 'passwd');
+      fs.readFileSync(escapePath);
+      tests.push({
+        test: 'Access parent directory with ../..',
+        path: escapePath,
+        success: false,
+        message: 'SECURITY BREACH: Able to escape sandbox!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Access parent directory with ../..',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试2: 尝试用多个../逃逸
+    try {
+      const escapePath = '../../../../../../../etc/hosts';
+      fs.readFileSync(escapePath);
+      tests.push({
+        test: 'Multiple ../ escape attempt',
+        path: escapePath,
+        success: false,
+        message: 'SECURITY BREACH: Able to escape sandbox!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Multiple ../ escape attempt',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试3: 尝试写入外部目录
+    try {
+      const escapePath = path.join('..', 'evil.txt');
+      fs.writeFileSync(escapePath, 'Should not be written');
+      tests.push({
+        test: 'Write to parent directory',
+        path: escapePath,
+        success: false,
+        message: 'SECURITY BREACH: Able to write outside sandbox!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Write to parent directory',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    return {
+      category: 'Relative Path Escape',
+      tests: tests,
+      passed: tests.filter(t => t.success).length,
+      total: tests.length
+    };
+  },
+
+  /**
+   * 测试绝对路径越权
+   */
+  async testAbsoluteEscape() {
+    const tests = [];
+    
+    // 测试1: 尝试访问系统文件
+    try {
+      fs.readFileSync('/etc/passwd');
+      tests.push({
+        test: 'Access /etc/passwd',
+        path: '/etc/passwd',
+        success: false,
+        message: 'SECURITY BREACH: Able to read system files!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Access /etc/passwd',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试2: 尝试访问用户主目录
+    try {
+      const homePath = process.env.HOME || '/home/user';
+      fs.readdirSync(homePath);
+      tests.push({
+        test: 'Access home directory',
+        path: homePath,
+        success: false,
+        message: 'SECURITY BREACH: Able to access home directory!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Access home directory',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试3: 尝试创建系统级文件
+    try {
+      fs.writeFileSync('/tmp/evil.txt', 'Should not exist');
+      tests.push({
+        test: 'Write to /tmp',
+        path: '/tmp/evil.txt',
+        success: false,
+        message: 'SECURITY BREACH: Able to write to /tmp!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Write to /tmp',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    return {
+      category: 'Absolute Path Escape',
+      tests: tests,
+      passed: tests.filter(t => t.success).length,
+      total: tests.length
+    };
+  },
+
+  /**
+   * 测试危险操作
+   */
+  async testDangerousOperations() {
+    const tests = [];
+    
+    // 测试1: 尝试使用child_process
+    try {
+      const child_process = require('child_process');
+      child_process.execSync('echo "Should not execute"');
+      tests.push({
+        test: 'Execute shell command',
+        success: false,
+        message: 'SECURITY BREACH: Able to execute shell commands!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Execute shell command',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试2: 尝试使用eval
+    try {
+      eval('console.log("Should not execute")');
+      tests.push({
+        test: 'Use eval()',
+        success: false,
+        message: 'SECURITY BREACH: eval() is allowed!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Use eval()',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试3: 尝试访问process.binding
+    try {
+      process.binding('fs');
+      tests.push({
+        test: 'Access process.binding',
+        success: false,
+        message: 'SECURITY BREACH: process.binding is accessible!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Access process.binding',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    // 测试4: 尝试使用path.resolve绕过
+    try {
+      const maliciousPath = path.resolve('/etc/passwd');
+      fs.readFileSync(maliciousPath);
+      tests.push({
+        test: 'Use path.resolve to bypass',
+        success: false,
+        message: 'SECURITY BREACH: path.resolve bypass worked!'
+      });
+    } catch (error) {
+      tests.push({
+        test: 'Use path.resolve to bypass',
+        success: true,
+        message: 'Correctly blocked: ' + error.message
+      });
+    }
+    
+    return {
+      category: 'Dangerous Operations',
+      tests: tests,
+      passed: tests.filter(t => t.success).length,
+      total: tests.length
+    };
+  },
+
+  /**
+   * 生成测试摘要
+   */
+  generateSummary(results) {
+    const totalTests = results.reduce((sum, r) => sum + r.total, 0);
+    const passedTests = results.reduce((sum, r) => sum + r.passed, 0);
+    const failedTests = totalTests - passedTests;
+    
+    const status = failedTests === 0 ? '✅ ALL TESTS PASSED' : `❌ ${failedTests} TESTS FAILED`;
+    
+    return {
+      status: status,
+      totalTests: totalTests,
+      passed: passedTests,
+      failed: failedTests,
+      passRate: `${((passedTests / totalTests) * 100).toFixed(1)}%`,
+      security: failedTests === 0 ? 'SECURE' : 'VULNERABLE'
+    };
+  }
+};

--- a/src/lib/tool/SandboxIsolationManager.js
+++ b/src/lib/tool/SandboxIsolationManager.js
@@ -47,7 +47,16 @@ class SandboxIsolationManager {
       
       // 4. 路径相关隔离
       __dirname: this.workingPath,
-      __filename: path.join(this.workingPath, 'sandbox.js')
+      __filename: path.join(this.workingPath, 'sandbox.js'),
+      
+      // 5. 注入受限的 fs（直接可用）
+      fs: this.createRestrictedFS(),
+      
+      // 6. 阻止动态代码执行
+      eval: () => {
+        throw new Error('[SandboxIsolation] eval is not allowed in sandbox');
+      },
+      Function: undefined
     };
 
     return this.isolatedContext;
@@ -73,6 +82,21 @@ class SandboxIsolationManager {
 
     // 返回增强的require函数
     return (moduleName) => {
+      // 拦截 fs 和相关模块
+      if (moduleName === 'fs' || moduleName === 'fs/promises') {
+        return this.createRestrictedFS();
+      }
+      
+      // 拦截 child_process，禁止使用
+      if (moduleName === 'child_process') {
+        throw new Error('[SandboxIsolation] child_process is not allowed in sandbox');
+      }
+      
+      // 拦截 path 模块，提供受限版本
+      if (moduleName === 'path') {
+        return this.createRestrictedPath();
+      }
+      
       try {
         // 优先使用沙箱require（自动处理符号链接）
         return sandboxRequire(moduleName);
@@ -102,7 +126,7 @@ class SandboxIsolationManager {
     // 2. 如果是分析阶段且模块不存在，返回mock对象
     if (this.options.analysisMode && error.code === 'MODULE_NOT_FOUND') {
       logger.debug(`[SandboxIsolation] Analysis mode: mocking module ${moduleName}`);
-      return this.createMockModule(moduleName);
+      return this.createMockModule();
     }
 
     // 3. 其他情况直接抛出原始错误
@@ -125,14 +149,150 @@ class SandboxIsolationManager {
 
   /**
    * 创建mock模块对象
-   * @param {string} moduleName - 模块名
    * @returns {Object} mock对象
    */
-  createMockModule(moduleName) {
+  createMockModule() {
     return new Proxy({}, {
       get: () => () => ({}),  // 所有属性和方法都返回空函数/对象
       apply: () => ({}),      // 如果被当作函数调用
       construct: () => ({})   // 如果被当作构造函数
+    });
+  }
+
+  /**
+   * 创建受限的文件系统
+   * 实现完全透明的拦截，在VM层面控制文件访问边界
+   * @returns {Object} 受限的fs对象
+   */
+  createRestrictedFS() {
+    const realFs = require('fs');
+    const boundary = path.resolve(this.workingPath); // 转为绝对路径
+    
+    logger.info(`[SandboxFS] Creating restricted FS with boundary: ${boundary}`);
+    
+    // 核心：智能路径解析，防止相对路径越权
+    const resolveSafePath = (inputPath) => {
+      // 处理undefined或null的情况
+      if (!inputPath) {
+        throw new Error('[SandboxFS] Path is required');
+      }
+      
+      // 1. 处理各种路径形式
+      let resolved;
+      
+      if (path.isAbsolute(inputPath)) {
+        // 绝对路径：直接解析
+        resolved = path.resolve(inputPath);
+      } else {
+        // 相对路径：基于 workingPath 解析
+        // 这是关键！防止 ../../ 越权
+        resolved = path.resolve(boundary, inputPath);
+      }
+      
+      // 2. 规范化路径（处理 .. 和 . ）
+      resolved = path.normalize(resolved);
+      
+      // 3. 边界检查
+      if (!resolved.startsWith(boundary)) {
+        // 记录详细信息用于调试
+        logger.error(`[SandboxFS] 文件访问越权尝试：
+          输入路径: ${inputPath}
+          解析结果: ${resolved}
+          允许边界: ${boundary}
+          调用栈: ${new Error().stack}
+        `);
+        
+        throw new Error(
+          `[SandboxFS] 文件访问被拒绝：路径 "${inputPath}" 超出工作目录边界 ${boundary}`
+        );
+      }
+      
+      return resolved;
+    };
+    
+    // 创建 Proxy 来拦截所有 fs 操作
+    const handler = {
+      get(target, prop) {
+        const original = target[prop];
+        
+        // 如果不是函数，直接返回
+        if (typeof original !== 'function') {
+          // 处理 fs.promises
+          if (prop === 'promises') {
+            return new Proxy(realFs.promises, {
+              get(promiseTarget, promiseProp) {
+                const promiseOriginal = promiseTarget[promiseProp];
+                if (typeof promiseOriginal !== 'function') {
+                  return promiseOriginal;
+                }
+                
+                // 包装 promises 方法
+                return async function(...args) {
+                  // 识别路径参数（通常是第一个）
+                  if (args.length > 0 && typeof args[0] === 'string') {
+                    args[0] = resolveSafePath(args[0]);
+                  }
+                  
+                  // 处理 rename、copyFile 等双路径操作
+                  if ((promiseProp === 'rename' || promiseProp === 'copyFile') && args.length > 1) {
+                    args[1] = resolveSafePath(args[1]);
+                  }
+                  
+                  // 调用原始函数
+                  return await promiseOriginal.apply(promiseTarget, args);
+                };
+              }
+            });
+          }
+          
+          return original;
+        }
+        
+        // 包装同步函数
+        return function(...args) {
+          // 识别路径参数（通常是第一个）
+          if (args.length > 0 && typeof args[0] === 'string') {
+            args[0] = resolveSafePath(args[0]);
+          }
+          
+          // 处理 rename、copyFile 等双路径操作
+          if ((prop === 'renameSync' || prop === 'copyFileSync') && args.length > 1) {
+            args[1] = resolveSafePath(args[1]);
+          }
+          
+          // 调用原始函数
+          return original.apply(target, args);
+        };
+      }
+    };
+    
+    // 返回代理的 fs 对象
+    return new Proxy(realFs, handler);
+  }
+
+  /**
+   * 创建受限的 path 模块
+   * 防止使用 path.resolve 绕过限制
+   * @returns {Object} 受限的path对象
+   */
+  createRestrictedPath() {
+    const realPath = require('path');
+    const boundary = path.resolve(this.workingPath);
+    
+    return new Proxy(realPath, {
+      get(target, prop) {
+        if (prop === 'resolve') {
+          return (...args) => {
+            const resolved = target.resolve(...args);
+            // 如果解析结果超出边界，记录警告
+            if (!resolved.startsWith(boundary)) {
+              logger.warn(`[SandboxPath] path.resolve 尝试越权: ${resolved}`);
+            }
+            return resolved;
+          };
+        }
+        return target[prop];
+      }
     });
   }
 
@@ -159,8 +319,16 @@ class SandboxIsolationManager {
       uptime: process.uptime,
       
       // 禁用危险方法
-      exit: () => { throw new Error('process.exit() is not allowed in sandbox'); },
-      abort: () => { throw new Error('process.abort() is not allowed in sandbox'); }
+      exit: () => { throw new Error('[SandboxIsolation] process.exit() is not allowed in sandbox'); },
+      abort: () => { throw new Error('[SandboxIsolation] process.abort() is not allowed in sandbox'); },
+      
+      // 阻止底层访问
+      binding: () => {
+        throw new Error('[SandboxIsolation] process.binding() is not allowed in sandbox');
+      },
+      dlopen: () => {
+        throw new Error('[SandboxIsolation] Native modules are not allowed in sandbox');
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
实现了 ToolSandbox 的 VM 层文件系统边界控制，确保工具无法访问工作目录之外的文件。

## 实现内容
- ✅ 在 SandboxIsolationManager 中实现 createRestrictedFS() 方法
- ✅ 透明拦截所有 fs 操作，自动检查路径边界
- ✅ 阻止相对路径(../)和绝对路径越权访问  
- ✅ 禁用危险操作(child_process, eval, process.binding)
- ✅ 添加 boundary-test 工具验证安全控制

## 测试结果
所有安全测试通过（100% 拦截率）：
- Normal Access: 2/2 passed ✅
- Relative Path Escape: 3/3 passed ✅ 
- Absolute Path Escape: 3/3 passed ✅
- Dangerous Operations: 4/4 passed ✅

## Related Issue
Closes #243

## Test plan
- [x] boundary-test 工具的所有测试用例通过
- [x] 正常文件操作不受影响
- [x] 路径越权被正确拦截
- [x] 危险操作被成功阻止

🤖 Generated with [Claude Code](https://claude.ai/code)