### PR TITLE
fix: 修复MCP SSE传输模式实现问题 (#248)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,5 @@
 
 - promptx 的日志打印需要使用utils中的 logger 而不是 console
 - promptx 项目的运行日志在 ~/.promptx/logs
+
+- 使用 pnpm 管理项目

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.1",
+    "@modelcontextprotocol/sdk": "^1.17.2",
     "@reaxi/node-detect-runtime": "^0.1.0",
     "body-parser": "^1.20.3",
     "boxen": "^5.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.17.1
-        version: 1.17.1
+        specifier: ^1.17.2
+        version: 1.17.2
       '@reaxi/node-detect-runtime':
         specifier: ^0.1.0
         version: 0.1.0
@@ -606,8 +606,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/sdk@1.17.1':
-    resolution: {integrity: sha512-CPle1OQehbWqd25La9Ack5B07StKIxh4+Bf19qnpZKJC1oI22Y0czZHbifjw1UoczIfKBwBDAp/dFxvHG13B5A==}
+  '@modelcontextprotocol/sdk@1.17.2':
+    resolution: {integrity: sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==}
     engines: {node: '>=18'}
 
   '@noble/hashes@1.8.0':
@@ -4456,7 +4456,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/sdk@1.17.1':
+  '@modelcontextprotocol/sdk@1.17.2':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5

--- a/src/bin/promptx.js
+++ b/src/bin/promptx.js
@@ -170,10 +170,10 @@ program
 program
   .command('mcp-server')
   .description('🔌 启动MCP Server，支持Claude Desktop等AI应用接入')
-  .option('-t, --transport <type>', '传输类型 (stdio|http|sse)', 'stdio')
-  .option('-p, --port <number>', 'HTTP端口号 (仅http/sse传输)', '3000')
-  .option('--host <address>', '绑定地址 (仅http/sse传输)', 'localhost')
-  .option('--cors', '启用CORS (仅http/sse传输)', false)
+  .option('-t, --transport <type>', '传输类型 (stdio|http)', 'stdio')
+  .option('-p, --port <number>', 'HTTP端口号 (仅http传输)', '3000')
+  .option('--host <address>', '绑定地址 (仅http传输)', 'localhost')
+  .option('--cors', '启用CORS (仅http传输)', false)
   .option('--debug', '启用调试模式', false)
   .action(async (options) => {
     try {
@@ -186,19 +186,18 @@ program
       if (options.transport === 'stdio') {
         const mcpServer = new MCPServerStdioCommand();
         await mcpServer.execute();
-      } else if (options.transport === 'http' || options.transport === 'sse') {
+      } else if (options.transport === 'http') {
         const mcpHttpServer = new MCPServerHttpCommand();
         const serverOptions = {
-          transport: options.transport,
           port: parseInt(options.port),
           host: options.host,
           cors: options.cors
         };
         
-        logger.info(chalk.green(`🚀 启动 ${options.transport.toUpperCase()} MCP Server 在 ${options.host}:${options.port}...`));
+        logger.info(chalk.green(`🚀 启动 HTTP MCP Server 在 ${options.host}:${options.port}...`));
         await mcpHttpServer.execute(serverOptions);
       } else {
-        throw new Error(`不支持的传输类型: ${options.transport}。支持的类型: stdio, http, sse`);
+        throw new Error(`不支持的传输类型: ${options.transport}。支持的类型: stdio, http`);
       }
     } catch (error) {
       // 输出到stderr，不污染MCP的stdout通信
@@ -257,8 +256,7 @@ ${chalk.cyan('示例:')}
 
   ${chalk.gray('# 8️⃣ 启动MCP服务')}
   promptx mcp-server                    # stdio传输(默认)
-  promptx mcp-server -t http -p 3000    # HTTP传输
-  promptx mcp-server -t sse -p 3001     # SSE传输
+  promptx mcp-server -t http -p 3000    # HTTP传输(Streamable HTTP)
 
 ${chalk.cyan('🔄 PATEOAS状态机:')}
   每个锦囊输出都包含 PATEOAS 导航，引导 AI 发现下一步操作


### PR DESCRIPTION
## 🎯 解决问题

修复Issue #248中描述的MCP SSE和HTTP传输模式实现问题。

## 📊 核心改动

### 1. 删除弃用的SSE独立实现
- ❌ 删除 SSEServerTransport 导入
- ❌ 删除 startSSEServer 等SSE专用方法（169-263行）
- ❌ 删除 /sse 和 /messages 端点

### 2. 统一使用Streamable HTTP
- ✅ 所有传输统一使用 StreamableHTTPServerTransport
- ✅ 单端点架构（/mcp）支持POST/GET/DELETE
- ✅ 更新SDK到最新版本 1.17.2

### 3. 更新CLI入口
- 移除SSE传输选项
- 简化传输类型判断逻辑
- 更新帮助文档示例

## 🔍 技术背景

MCP协议从2024年11月起弃用了独立的SSE传输模式，转向Streamable HTTP。新模式的优势：
- 单一端点设计更简洁
- 支持智能选择响应方式（JSON或SSE流）
- 更好的session管理和断线重连支持

## ✅ 测试验证

- [x] 服务器正常启动
- [x] 健康检查端点响应正常
- [x] 代码检查无新增错误

## 📝 备注

- 保留了OAuth的mock实现避免客户端连接时报错
- SSE技术仍在使用，但作为Streamable HTTP的流式响应实现细节
- 未来可根据需要添加真实的OAuth认证

Closes #248