### PR TITLE
fix: 测试 GH_PAT 配置的发布流程

### DIFF
--- a/.changeset/fix-test-publish.md
+++ b/.changeset/fix-test-publish.md
@@ -1,0 +1,5 @@
+---
+"@promptx/cli": patch
+---
+
+修复 changeset 的 GitHub token 配置


### PR DESCRIPTION
## 测试目的

验证修复后的 GH_PAT 配置是否能正常工作

## 期望结果
- auto-labeler 应该添加：
  - `changeset/patch`
  - `merge/squash`  
  - `publish/dev`
- 合并后应该正常发布到 npm dev tag

---
🧪 测试 PR