### PR TITLE
feat(desktop): add About dialog to tray menu

### DIFF
--- a/.changeset/apple-code-signing.md
+++ b/.changeset/apple-code-signing.md
@@ -1,0 +1,9 @@
+---
+"@promptx/desktop": patch
+---
+
+feat(desktop): add About dialog to tray menu
+
+- Add About dialog accessible from system tray menu
+- Display app version and basic information
+- Improve user experience with easy access to app details


### PR DESCRIPTION
## Summary
- Add About dialog accessible from system tray menu
- Display app version and basic information
- Improve user experience with easy access to app details

## Changes
- ✅ Added About dialog feature to desktop app
- ✅ Updated tray menu with About option
- ✅ Added changeset for version tracking

## Test plan
- [ ] Build and test desktop app
- [ ] Verify About dialog appears from tray menu
- [ ] Confirm version information is displayed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)