### PR TITLE
fix: remove manual update check button and enhance logging

### DIFF
--- a/.changeset/fix-auto-update-detection.md
+++ b/.changeset/fix-auto-update-detection.md
@@ -1,0 +1,12 @@
+---
+"@promptx/desktop": patch
+---
+
+Fix auto-update detection issue (#336)
+
+- Remove manual "Check for Updates" button from tray menu to avoid user confusion
+- Add comprehensive ASCII-only logging for auto-updater events  
+- Simplify update manager to rely on automatic 1-hour update checks
+- Clean up unused dialog and icon loading code
+
+The manual update check button was ineffective due to update-electron-app's stateless design. When users selected "Later" on an update, the library wouldn't re-prompt for the same version. This change removes the confusing button and adds detailed logging to track update status transparently.

--- a/apps/desktop/electron-builder-dev.yml
+++ b/apps/desktop/electron-builder-dev.yml
@@ -28,18 +28,18 @@ files:
 mac:
   category: public.app-category.developer-tools
   icon: assets/icons/icon.icns
-  hardenedRuntime: false  # 本地测试关闭强化运行时
+  hardenedRuntime: true  # 启用强化运行时以匹配生产环境
   gatekeeperAssess: false
-  # 完全跳过签名
-  identity: null
-  notarize: false
+  # 使用公司证书签名
+  identity: "CHINGHO YANG (2L3974JGL8)"
+  notarize: false  # 本地测试暂不公证
   # 只打 ZIP 包，不打 DMG
   target:
     - target: zip
       arch: [arm64]  # 只打当前架构，更快
 
-# 关闭所有签名
-forceCodeSigning: false
+# 启用代码签名
+forceCodeSigning: true
 
 # 禁用 npm rebuild，加快速度
 npmRebuild: false

--- a/apps/desktop/src/main/tray/TrayPresenter.ts
+++ b/apps/desktop/src/main/tray/TrayPresenter.ts
@@ -167,13 +167,6 @@ export class TrayPresenter {
       click: () => this.handleShowLogs()
     })
 
-    // Check for updates
-    menuItems.push({
-      id: 'update',
-      label: this.updateManager.isUpdateAvailable() ? 'Update Available!' : 'Check for Updates',
-      click: () => this.handleCheckUpdate()
-    })
-
     // Settings (future)
     menuItems.push({
       id: 'settings',
@@ -291,15 +284,6 @@ return
     })
   }
 
-  handleCheckUpdate(): void {
-    logger.info('TrayPresenter: handleCheckUpdate called')
-    try {
-      this.updateManager.checkForUpdatesManual()
-      logger.info('TrayPresenter: checkForUpdatesManual called successfully')
-    } catch (error) {
-      logger.error('TrayPresenter: Error calling checkForUpdatesManual:', error)
-    }
-  }
 
   handleQuit(): void {
     app.quit()


### PR DESCRIPTION
## Summary
- Removed ineffective "Check for Updates" button from tray menu
- Added comprehensive ASCII-only logging for auto-updater events  
- Enabled code signing in electron-builder-dev.yml for consistent testing

## Background
Fixes #336 

The manual update check button was ineffective due to `update-electron-app`'s stateless design. When users selected "Later" on an update notification, the library wouldn't re-prompt for the same version, creating a confusing user experience.

## Changes
1. **Removed manual check button**: The button in the tray menu has been removed to avoid user confusion
2. **Enhanced logging**: Added detailed event listeners for all auto-updater events with ASCII-only messages
3. **Code signing**: Enabled code signing in dev builds to match production environment
4. **Simplified update manager**: Removed unused dialog and icon loading code

## Implementation Details
- Auto-updater continues to run every hour automatically
- All update events are now logged transparently for debugging
- The `checkForUpdatesManual()` method is preserved but simplified to logging-only for backward compatibility

## Test Plan
- [x] Build passes successfully
- [ ] Auto-updater logs events correctly in packaged app
- [ ] No UI confusion with missing button
- [ ] Code signing works in dev builds

🤖 Generated with [Claude Code](https://claude.ai/code)