### PR TITLE
feat: 使用 Cloudflare R2 优化国内用户自动更新体验

### DIFF
--- a/.changeset/r2-cdn-auto-update.md
+++ b/.changeset/r2-cdn-auto-update.md
@@ -1,0 +1,9 @@
+---
+"@promptx/desktop": patch
+---
+
+使用 Cloudflare R2 优化国内用户自动更新体验
+
+- 配置多 provider 自动更新策略：GitHub 优先，R2 兜底
+- 发布时自动同步安装包到 Cloudflare R2
+- 国内用户可通过 CDN 加速下载更新

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -410,8 +410,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Upload to Cloudflare R2
+        run: |
+          # 安装 wrangler
+          npm install -g wrangler
+
+          # 提取版本号（去掉 v 前缀）
+          VERSION=${GITHUB_REF_NAME#v}
+
+          # 上传所有发布文件到 R2
+          for file in release-files/*; do
+            if [ -f "$file" ]; then
+              filename=$(basename "$file")
+              echo "Uploading $filename to R2..."
+
+              # 上传到版本目录（归档）
+              npx wrangler r2 object put "promptx-releases/$VERSION/$filename" \
+                --file "$file" \
+                --content-type "application/octet-stream"
+
+              # 同时上传到 latest 目录（自动更新）
+              npx wrangler r2 object put "promptx-releases/latest/$filename" \
+                --file "$file" \
+                --content-type "application/octet-stream"
+            fi
+          done
+
+          echo "✅ All files uploaded to R2:"
+          echo "  - Version: promptx-releases/$VERSION/"
+          echo "  - Latest: promptx-releases/latest/"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Summary
         run: |
+          VERSION=${GITHUB_REF_NAME#v}
           echo "## 🎉 Desktop Apps Released Successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
@@ -420,8 +454,12 @@ jobs:
           echo "- macOS: Built and Notarized" >> $GITHUB_STEP_SUMMARY
           echo "- Windows: Built and Signed" >> $GITHUB_STEP_SUMMARY
           echo "- Linux: Built (deb, AppImage, rpm)" >> $GITHUB_STEP_SUMMARY
+          echo "- R2: Synced to Cloudflare R2" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📦 Release Contents:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           ls -lh release-files/ >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🌐 CDN URLs:" >> $GITHUB_STEP_SUMMARY
+          echo "- Base URL: https://r2.deepractice.ai/promptx-releases/$VERSION/" >> $GITHUB_STEP_SUMMARY

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -85,8 +85,11 @@ npmRebuild: true
 generateUpdatesFilesForAllChannels: true
 
 # 发布配置
+# 优先级顺序：GitHub (国外/有梯子) → R2 (国内兜底)
 publish:
   - provider: github
     owner: Deepractice
     repo: PromptX
     releaseType: release
+  - provider: generic
+    url: https://r2.deepractice.ai/promptx-releases/latest


### PR DESCRIPTION
## 背景

GitHub Releases 在国内访问不稳定，没有梯子的用户无法正常使用自动更新功能。

## 解决方案

使用 Cloudflare R2 + Worker 提供国内友好的 CDN 加速，同时保持 GitHub 优先策略以节省流量费用。

## 实现细节

### 1. Cloudflare 基础设施

- **R2 Bucket**: `promptx-releases`
- **Worker**: 多桶路由服务
- **CDN 域名**: https://r2.deepractice.ai
- **仓库**: https://github.com/Deepractice/DeepracticeCloudflare

### 2. 发布流程改进

- GitHub Actions 在发布后自动同步到 R2
- 双目录结构：
  - `promptx-releases/{version}/`: 版本归档
  - `promptx-releases/latest/`: 自动更新

### 3. AutoUpdater 策略

- **优先**: GitHub Releases（国外/有梯子用户）
- **降级**: R2 CDN（国内用户兜底）
- **优势**: GitHub 优先可节省 R2 流量费用

## 测试计划

- [ ] 配置 GitHub Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
- [ ] 下次发布时验证 R2 自动上传
- [ ] 测试国内用户自动更新功能
- [ ] 验证 GitHub 优先策略生效

## 相关资源

- Issue: #417
- DeepracticeCloudflare: https://github.com/Deepractice/DeepracticeCloudflare
- R2 Router Worker: 已部署到 https://r2.deepractice.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)