### PR TITLE
fix: change getInfo() return key to sandboxPath

### DIFF
--- a/.changeset/getinfo-sandboxpath.md
+++ b/.changeset/getinfo-sandboxpath.md
@@ -1,0 +1,5 @@
+---
+"@promptx/core": patch
+---
+
+Fix getInfo() return key from 'sandbox' to 'sandboxPath' for semantic consistency with class property naming.

--- a/packages/core/src/toolx/api/ToolAPI.js
+++ b/packages/core/src/toolx/api/ToolAPI.js
@@ -111,7 +111,7 @@ class ToolAPI {
   getInfo() {
     return {
       id: this.toolId,
-      sandbox: this.sandboxPath,
+      sandboxPath: this.sandboxPath,
       runtime: {
         node: process.version,
         platform: process.platform,


### PR DESCRIPTION
## 问题

`api.getInfo()` 返回对象的 key 是 `sandbox`，但类属性名是 `sandboxPath`，语义不一致：

```javascript
// ToolAPI 构造函数
this.sandboxPath = sandboxPath;

// 但 getInfo() 返回
return {
  sandbox: this.sandboxPath  // ❌ key 名不一致
}
```

导致使用方会写出 `toolInfo.sandboxPath` 但拿到 `undefined`。

## 解决方案

统一使用 `sandboxPath`：

```javascript
return {
  id: this.toolId,
  sandboxPath: this.sandboxPath,  // ✅ 统一命名
  runtime: { ... }
}
```

## 影响

如果有代码使用了 `toolInfo.sandbox`，需要改成 `toolInfo.sandboxPath`。