### PR TITLE
fix(resource): filesystem tool ALLOWED_DIRECTORIES JSON parsing

### DIFF
--- a/.changeset/fix-filesystem-env-json-parsing.md
+++ b/.changeset/fix-filesystem-env-json-parsing.md
@@ -1,0 +1,5 @@
+---
+"@promptx/resource": patch
+---
+
+Fix filesystem tool ALLOWED_DIRECTORIES environment variable JSON parsing issue. The tool now properly handles escaped quotes from .env file format, allowing configuration of multiple allowed directories.


### PR DESCRIPTION
## Summary

Fixed a bug in the filesystem tool where `ALLOWED_DIRECTORIES` environment variable couldn't be parsed due to escaped quotes from .env file format.

## Problem

When configuring multiple allowed directories like:
```json
["~/.promptx", "/Users/sean/Deepractice"]
```

The ToolEnvironment class escapes quotes when saving to .env format, resulting in:
```
ALLOWED_DIRECTORIES="[\"~/.promptx\", \"/Users/sean/Deepractice\"]"
```

The filesystem tool attempted to parse this directly as JSON, which failed due to the escaped quotes.

## Solution

Added proper unescaping logic in the `getAllowedDirectories()` method (line 209) to handle escaped quotes before JSON parsing:
```javascript
configStr = configStr.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
```

## Test plan

- [x] Configure multiple allowed directories
- [x] Verify directories are properly parsed and accessible
- [x] Test with `/Users/sean/Deepractice` - successfully lists directory
- [x] Test with `/Users` - successfully lists directory
- [x] Generated changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)