### PR TITLE
ci: fix workflow YAML syntax error

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -309,16 +309,9 @@ jobs:
           release_date=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
 
           # 创建 latest.yml - 使用双引号包裹 sha512 确保单行
-          cat > latest.yml <<YAMLEOF
-version: ${version}
-files:
-  - url: ${signed_exe}
-    sha512: "${sha512_hash}"
-    size: ${file_size}
-path: ${signed_exe}
-sha512: "${sha512_hash}"
-releaseDate: '${release_date}'
-YAMLEOF
+          printf "version: %s\nfiles:\n  - url: %s\n    sha512: \"%s\"\n    size: %s\npath: %s\nsha512: \"%s\"\nreleaseDate: '%s'\n" \
+            "${version}" "${signed_exe}" "${sha512_hash}" "${file_size}" \
+            "${signed_exe}" "${sha512_hash}" "${release_date}" > latest.yml
 
           # 验证生成的 YAML 格式
           echo "Generated latest.yml:"


### PR DESCRIPTION
## 🐛 Hotfix: Workflow YAML Syntax Error

Fixes the YAML parsing error introduced in PR #454.

### Problem
The heredoc syntax () in the GitHub Actions workflow causes the YAML parser to treat the heredoc **content** as part of the workflow YAML structure, resulting in syntax errors:

```
Error: workflow is not valid. 'release-desktop.yml': 
yaml: line 321: could not find expected ':'
```

### Root Cause
GitHub Actions YAML parser gets confused by heredoc syntax in `run:` blocks. It interprets:

```yaml
cat > latest.yml <<YAMLEOF
version: ${version}
files:
  - url: ${signed_exe}
YAMLEOF
```

As if `version:`, `files:` etc. are workflow YAML keys, not heredoc content.

### Solution
Replace heredoc with `printf`:

```bash
printf "version: %s\nfiles:\n  - url: %s\n..." > latest.yml
```

This keeps the shell script separate from workflow YAML structure.

### Validation
✅ Validated with `act -l` - no errors
✅ Syntax check passes

### Impact
- Fixes workflow validation errors
- Allows future releases to build successfully  
- No functional changes to generated latest.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>