### PR TITLE
fix(desktop): stop bubbling on resource action icons to avoid edit modal

### DIFF
--- a/.changeset/pink-points-strive.md
+++ b/.changeset/pink-points-strive.md
@@ -1,0 +1,12 @@
+---
+"@promptx/desktop": patch
+---
+
+Resource Manager UX: Prevent the edit modal from opening when clicking action icons
+
+- Context: Resource cards use `onClick` to open the edit modal. Clicking right-side action icons (Edit, View/External link, Delete) bubbled to the card, unintentionally triggering the modal.
+- Fix: Call `e.stopPropagation()` in each icon’s `onClick` (or on the icon container) to block event bubbling and ensure only the intended action runs.
+- Touched file: `apps/desktop/src/view/pages/resources-window/index.tsx`.
+- Impact: Affects the behavior of “Edit”, “View/External link”, and “Delete” icons on role/tool cards.
+- UX: Clicking action icons now performs the expected operation without opening the editor.
+- Compatibility: Non-breaking patch; no API or data shape changes.

--- a/apps/desktop/src/view/pages/resources-window/index.tsx
+++ b/apps/desktop/src/view/pages/resources-window/index.tsx
@@ -271,11 +271,35 @@ export default function ResourcesPage() {
                 </span>
                 <span className="flex items-center gap-3">
                   {/* 编辑 */}
-                  {item.source === "user" && <SquarePen className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-[#1f6feb]" onClick={() => handleEdit(item)} />}
+                  {item.source === "user" && (
+                    <SquarePen
+                      className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-[#1f6feb]"
+                      onClick={e => {
+                        e.stopPropagation()
+                        handleEdit(item)
+                      }}
+                    />
+                  )}
                   {/* 查看/外链 */}
-                  {item.source === "user" && <FolderDown className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-[#1f6feb]" onClick={() => handleView(item)} />}
+                  {item.source === "user" && (
+                    <FolderDown
+                      className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-[#1f6feb]"
+                      onClick={e => {
+                        e.stopPropagation()
+                        handleView(item)
+                      }}
+                    />
+                  )}
                   {/* 删除 */}
-                  {item.source === "user" && <Trash className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-red-600" onClick={() => handleDelete(item)} />}
+                  {item.source === "user" && (
+                    <Trash
+                      className="h-5 w-5 cursor-pointer transition-transform duration-200 hover:scale-[1.1] hover:text-red-600"
+                      onClick={e => {
+                        e.stopPropagation()
+                        handleDelete(item)
+                      }}
+                    />
+                  )}
                 </span>
               </CardTitle>
             </CardHeader>


### PR DESCRIPTION
esource Manager UX: Prevent the edit modal from opening when clicking action icons

- Context: Resource cards use `onClick` to open the edit modal. Clicking right-side action icons (Edit, View/External link, Delete) bubbled to the card, unintentionally triggering the modal.
- Fix: Call `e.stopPropagation()` in each icon’s `onClick` (or on the icon container) to block event bubbling and ensure only the intended action runs.
- Touched file: `apps/desktop/src/view/pages/resources-window/index.tsx`.
- Impact: Affects the behavior of “Edit”, “View/External link”, and “Delete” icons on role/tool cards.
- UX: Clicking action icons now performs the expected operation without opening the editor.
- Compatibility: Non-breaking patch; no API or data shape changes.