### PR TITLE
feat(dpml): add role composition support with @!role:// protocol

### DIFF
--- a/packages/core/test/SemanticRenderer.role-compose.test.js
+++ b/packages/core/test/SemanticRenderer.role-compose.test.js
@@ -1,0 +1,290 @@
+/**
+ * SemanticRenderer Role Composition Test Suite
+ * Test the @!role:// protocol support for role composition
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const SemanticRenderer = require('../src/dpml/SemanticRenderer');
+const DPMLContentParser = require('../src/dpml/DPMLContentParser');
+
+describe('SemanticRenderer - Role Composition', () => {
+  let renderer;
+  let parser;
+  let mockResourceManager;
+
+  beforeEach(() => {
+    renderer = new SemanticRenderer({ renderMode: 'semantic' });
+    parser = new DPMLContentParser();
+
+    // Mock resource manager
+    mockResourceManager = {
+      resolve: vi.fn()
+    };
+  });
+
+  describe('Role Protocol Support', () => {
+    it('should have role in semanticHeaders', () => {
+      // Test that role protocol has a semantic header
+      const content = renderer.wrapReferenceContent('role', 'test-role', 'test content');
+      expect(content).toContain('🎭 组合角色：test-role');
+    });
+
+    it('should parse @!role:// references', () => {
+      const content = `
+@!role://liutianchi
+@!role://venus
+@!role://director
+`;
+      const references = parser.extractReferences(content);
+
+      expect(references).toHaveLength(3);
+      expect(references[0].protocol).toBe('role');
+      expect(references[0].resource).toBe('liutianchi');
+      expect(references[1].protocol).toBe('role');
+      expect(references[1].resource).toBe('venus');
+      expect(references[2].protocol).toBe('role');
+      expect(references[2].resource).toBe('director');
+    });
+  });
+
+  describe('Recursive Role Rendering', () => {
+    it('should recursively render role content with nested references', async () => {
+      // Mock a role that contains knowledge references
+      const roleContent = `
+<role>
+# Test Role
+
+<personality>
+I am a test role.
+@!knowledge://test-knowledge
+</personality>
+
+<principle>
+Follow best practices.
+</principle>
+
+<knowledge>
+Domain knowledge here.
+</knowledge>
+
+</role>
+`;
+
+      const knowledgeContent = `
+<knowledge>
+This is the test knowledge content.
+</knowledge>
+`;
+
+      mockResourceManager.resolve.mockImplementation(async (ref) => {
+        if (ref.includes('role://test-role')) {
+          return { success: true, content: roleContent };
+        }
+        if (ref.includes('knowledge://test-knowledge')) {
+          return { success: true, content: knowledgeContent };
+        }
+        return { success: false, error: { message: 'Not found' } };
+      });
+
+      const tagSemantics = parser.parseTagContent('@!role://test-role', 'test');
+      const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+      expect(result).toContain('🎭 组合角色：test-role');
+      expect(result).toContain('💭 思维模式');
+      expect(result).toContain('This is the test knowledge content');
+    });
+  });
+
+  describe('Circular Reference Detection', () => {
+    it('should detect and handle circular role references', async () => {
+      // Role A references Role B, Role B references Role A
+      const roleAContent = `
+<role>
+<personality>
+I am Role A.
+@!role://role-b
+</personality>
+</role>
+`;
+
+      const roleBContent = `
+<role>
+<personality>
+I am Role B.
+@!role://role-a
+</personality>
+</role>
+`;
+
+      mockResourceManager.resolve.mockImplementation(async (ref) => {
+        if (ref.includes('role://role-a')) {
+          return { success: true, content: roleAContent };
+        }
+        if (ref.includes('role://role-b')) {
+          return { success: true, content: roleBContent };
+        }
+        return { success: false, error: { message: 'Not found' } };
+      });
+
+      const tagSemantics = parser.parseTagContent('@!role://role-a', 'test');
+      const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+      // Should contain cycle detection warning
+      expect(result).toContain('循环引用');
+    });
+
+    it('should allow same role in different branches', async () => {
+      // Role Composite references both Role A and Role B
+      // Both Role A and Role B reference a shared knowledge
+      const compositeContent = `
+<role>
+<personality>
+@!role://role-a
+@!role://role-b
+</personality>
+</role>
+`;
+
+      const roleAContent = `
+<role>
+<knowledge>
+@!knowledge://shared
+</knowledge>
+</role>
+`;
+
+      const roleBContent = `
+<role>
+<knowledge>
+@!knowledge://shared
+</knowledge>
+</role>
+`;
+
+      const sharedKnowledge = `
+<knowledge>
+Shared knowledge content.
+</knowledge>
+`;
+
+      mockResourceManager.resolve.mockImplementation(async (ref) => {
+        if (ref.includes('role://composite')) {
+          return { success: true, content: compositeContent };
+        }
+        if (ref.includes('role://role-a')) {
+          return { success: true, content: roleAContent };
+        }
+        if (ref.includes('role://role-b')) {
+          return { success: true, content: roleBContent };
+        }
+        if (ref.includes('knowledge://shared')) {
+          return { success: true, content: sharedKnowledge };
+        }
+        return { success: false, error: { message: 'Not found' } };
+      });
+
+      const tagSemantics = parser.parseTagContent('@!role://composite', 'test');
+      const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+      // Should successfully render without circular reference errors
+      // because each branch has its own visitedRoles set
+      expect(result).not.toContain('循环引用');
+      expect(result).toContain('Shared knowledge content');
+    });
+  });
+
+  describe('Multi-Role Composition', () => {
+    it('should compose multiple roles in a single personality tag', async () => {
+      const role1Content = `
+<role>
+<personality>
+I am Liu Tianchi, acting teacher.
+</personality>
+<principle>
+Stanislavski method.
+</principle>
+</role>
+`;
+
+      const role2Content = `
+<role>
+<personality>
+I am Venus, film theorist.
+</personality>
+<principle>
+Structural analysis.
+</principle>
+</role>
+`;
+
+      const role3Content = `
+<role>
+<personality>
+I am Director.
+</personality>
+<principle>
+Visual storytelling.
+</principle>
+</role>
+`;
+
+      mockResourceManager.resolve.mockImplementation(async (ref) => {
+        if (ref.includes('role://liutianchi')) {
+          return { success: true, content: role1Content };
+        }
+        if (ref.includes('role://venus')) {
+          return { success: true, content: role2Content };
+        }
+        if (ref.includes('role://director')) {
+          return { success: true, content: role3Content };
+        }
+        return { success: false, error: { message: 'Not found' } };
+      });
+
+      const compositeSemantics = parser.parseTagContent(`
+## 三位专家组成圆桌讨论
+
+@!role://liutianchi
+@!role://venus
+@!role://director
+`, 'personality');
+
+      const result = await renderer.renderSemanticContent(compositeSemantics, mockResourceManager);
+
+      expect(result).toContain('🎭 组合角色：liutianchi');
+      expect(result).toContain('🎭 组合角色：venus');
+      expect(result).toContain('🎭 组合角色：director');
+      expect(result).toContain('Liu Tianchi');
+      expect(result).toContain('Venus');
+      expect(result).toContain('Director');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should gracefully handle role resolution failure', async () => {
+      mockResourceManager.resolve.mockResolvedValue({
+        success: false,
+        error: { message: 'Role not found in registry' }
+      });
+
+      const tagSemantics = parser.parseTagContent('@!role://nonexistent', 'test');
+      const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+      expect(result).toContain('引用加载失败');
+      expect(result).toContain('nonexistent');
+    });
+
+    it('should handle resolve exceptions gracefully', async () => {
+      mockResourceManager.resolve.mockRejectedValue(new Error('Network error'));
+
+      const tagSemantics = parser.parseTagContent('@!role://broken', 'test');
+      const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+      expect(result).toContain('引用解析异常');
+      expect(result).toContain('Network error');
+    });
+  });
+});

--- a/packages/core/test/e2e-role-compose.test.js
+++ b/packages/core/test/e2e-role-compose.test.js
@@ -1,0 +1,194 @@
+/**
+ * E2E Test: Role Composition with @!role:// References
+ *
+ * 这个测试使用真实的 ResourceManager 来验证角色组合功能
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// 直接使用源码（绕过 @promptx/logger 依赖问题）
+const SemanticRenderer = require('../src/dpml/SemanticRenderer');
+const DPMLContentParser = require('../src/dpml/DPMLContentParser');
+
+// 用户资源目录
+const USER_RESOURCE_DIR = path.join(process.env.HOME, '.promptx/resource/role');
+
+// 简单的 Mock ResourceManager - 直接读取文件
+class SimpleResourceManager {
+  constructor(userResourceDir) {
+    this.userResourceDir = userResourceDir;
+    this.cache = new Map();
+  }
+
+  async resolve(resourceRef) {
+    console.log(`[SimpleResourceManager] Resolving: ${resourceRef}`);
+
+    try {
+      // 解析协议和路径
+      const match = resourceRef.match(/@[!?]?([a-zA-Z]+):\/\/(.+)/);
+      if (!match) {
+        return { success: false, error: { message: `Invalid reference: ${resourceRef}` } };
+      }
+
+      const [, protocol, resourceId] = match;
+
+      // 根据协议类型查找文件
+      let filePath;
+      let content;
+
+      switch (protocol) {
+        case 'role':
+          filePath = path.join(this.userResourceDir, resourceId, `${resourceId}.role.md`);
+          break;
+        case 'thought':
+          // 搜索所有角色目录下的 thought 文件
+          filePath = this.findResourceFile(resourceId, 'thought');
+          break;
+        case 'execution':
+          filePath = this.findResourceFile(resourceId, 'execution');
+          break;
+        case 'knowledge':
+          filePath = this.findResourceFile(resourceId, 'knowledge');
+          break;
+        default:
+          return { success: false, error: { message: `Unknown protocol: ${protocol}` } };
+      }
+
+      if (!filePath || !fs.existsSync(filePath)) {
+        console.log(`[SimpleResourceManager] File not found: ${filePath || resourceId}`);
+        // 返回占位符而不是失败
+        return {
+          success: true,
+          content: `<${protocol}>\n[${resourceId} - 资源未找到，使用占位符]\n</${protocol}>`
+        };
+      }
+
+      content = fs.readFileSync(filePath, 'utf-8');
+      console.log(`[SimpleResourceManager] Loaded: ${filePath} (${content.length} bytes)`);
+
+      return { success: true, content };
+    } catch (error) {
+      console.error(`[SimpleResourceManager] Error:`, error.message);
+      return { success: false, error };
+    }
+  }
+
+  findResourceFile(resourceId, type) {
+    // 遍历所有角色目录查找资源
+    const roleDirs = fs.readdirSync(this.userResourceDir).filter(f => {
+      const fullPath = path.join(this.userResourceDir, f);
+      return fs.statSync(fullPath).isDirectory() && !f.startsWith('.');
+    });
+
+    for (const roleDir of roleDirs) {
+      const typePath = path.join(this.userResourceDir, roleDir, type);
+      if (fs.existsSync(typePath)) {
+        const files = fs.readdirSync(typePath);
+        const targetFile = files.find(f => f.startsWith(resourceId));
+        if (targetFile) {
+          return path.join(typePath, targetFile);
+        }
+      }
+    }
+
+    return null;
+  }
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('E2E Test: Role Composition with @!role:// References');
+  console.log('='.repeat(60));
+  console.log();
+
+  // 1. 初始化
+  const renderer = new SemanticRenderer({ renderMode: 'semantic' });
+  const parser = new DPMLContentParser();
+  const resourceManager = new SimpleResourceManager(USER_RESOURCE_DIR);
+
+  // 2. 读取组合角色文件
+  const compositeRolePath = path.join(USER_RESOURCE_DIR, 'acting-roundtable-v2/acting-roundtable-v2.role.md');
+
+  if (!fs.existsSync(compositeRolePath)) {
+    console.error(`❌ 组合角色文件不存在: ${compositeRolePath}`);
+    console.log('请先创建 acting-roundtable-v2 角色');
+    process.exit(1);
+  }
+
+  const compositeContent = fs.readFileSync(compositeRolePath, 'utf-8');
+  console.log('✅ 读取组合角色文件成功');
+  console.log();
+
+  // 3. 解析角色文档
+  const roleSemantics = parser.parseRoleDocument(compositeContent);
+  console.log('✅ 解析角色文档成功');
+  console.log('   - personality:', roleSemantics.personality ? '有' : '无');
+  console.log('   - principle:', roleSemantics.principle ? '有' : '无');
+  console.log('   - knowledge:', roleSemantics.knowledge ? '有' : '无');
+  console.log();
+
+  // 4. 检查 personality 中的引用
+  if (roleSemantics.personality) {
+    const refs = roleSemantics.personality.references;
+    console.log(`📋 发现 ${refs.length} 个引用:`);
+    refs.forEach(ref => {
+      console.log(`   - ${ref.fullMatch} (protocol: ${ref.protocol}, required: ${ref.isRequired})`);
+    });
+    console.log();
+  }
+
+  // 5. 渲染 personality 内容
+  console.log('🔄 开始渲染 personality 内容...');
+  console.log();
+
+  try {
+    const renderedContent = await renderer.renderSemanticContent(
+      roleSemantics.personality,
+      resourceManager
+    );
+
+    console.log('='.repeat(60));
+    console.log('渲染结果预览 (前 3000 字符):');
+    console.log('='.repeat(60));
+    console.log(renderedContent.substring(0, 3000));
+    if (renderedContent.length > 3000) {
+      console.log(`\n... (还有 ${renderedContent.length - 3000} 字符)`);
+    }
+    console.log();
+    console.log('='.repeat(60));
+
+    // 6. 验证结果
+    console.log('验证结果:');
+
+    const checks = [
+      { name: '包含 🎭 组合角色：liutianchi', pass: renderedContent.includes('🎭 组合角色：liutianchi') },
+      { name: '包含 🎭 组合角色：venus', pass: renderedContent.includes('🎭 组合角色：venus') },
+      { name: '包含 🎭 组合角色：director', pass: renderedContent.includes('🎭 组合角色：director') },
+      { name: '包含刘天池的内容', pass: renderedContent.includes('刘天池') },
+      { name: '包含维纳斯的内容', pass: renderedContent.includes('维纳斯') || renderedContent.includes('Venus') },
+      { name: '包含导演的内容', pass: renderedContent.includes('电影导演') || renderedContent.includes('视觉叙事') },
+      { name: '不包含原始引用标记', pass: !renderedContent.includes('@!role://') },
+    ];
+
+    let allPass = true;
+    checks.forEach(check => {
+      const status = check.pass ? '✅' : '❌';
+      console.log(`   ${status} ${check.name}`);
+      if (!check.pass) allPass = false;
+    });
+
+    console.log();
+    if (allPass) {
+      console.log('🎉 所有验证通过！角色组合功能正常工作！');
+    } else {
+      console.log('⚠️  部分验证失败，需要检查');
+    }
+
+  } catch (error) {
+    console.error('❌ 渲染失败:', error.message);
+    console.error(error.stack);
+  }
+}
+
+main().catch(console.error);

--- a/packages/core/test/integration/role-compose.integration.test.js
+++ b/packages/core/test/integration/role-compose.integration.test.js
@@ -1,0 +1,172 @@
+/**
+ * Role Composition Integration Test
+ *
+ * This test verifies that @!role:// references work with real role files
+ * in the user's ~/.promptx/resource/role directory.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createRequire } from 'module';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const require = createRequire(import.meta.url);
+const SemanticRenderer = require('../../src/dpml/SemanticRenderer');
+const DPMLContentParser = require('../../src/dpml/DPMLContentParser');
+
+// Helper to read file content
+const readFile = (filePath) => fs.readFileSync(filePath, 'utf-8');
+
+// User resource directory
+const USER_RESOURCE_DIR = path.join(process.env.HOME, '.promptx/resource/role');
+
+describe('Role Composition Integration Test', () => {
+  let renderer;
+  let parser;
+  let mockResourceManager;
+
+  // Real role contents
+  let liutianchiContent;
+  let venusContent;
+  let directorContent;
+  let compositeContent;
+
+  beforeAll(() => {
+    renderer = new SemanticRenderer({ renderMode: 'semantic' });
+    parser = new DPMLContentParser();
+
+    // Load real role files
+    const liutianchiPath = path.join(USER_RESOURCE_DIR, 'liutianchi/liutianchi.role.md');
+    const venusPath = path.join(USER_RESOURCE_DIR, 'venus/venus.role.md');
+    const directorPath = path.join(USER_RESOURCE_DIR, 'director/director.role.md');
+    const compositePath = path.join(USER_RESOURCE_DIR, 'acting-roundtable-v2/acting-roundtable-v2.role.md');
+
+    // Check if files exist
+    if (!fs.existsSync(liutianchiPath)) {
+      console.log('Skipping integration test: liutianchi role not found');
+      return;
+    }
+
+    liutianchiContent = readFile(liutianchiPath);
+    venusContent = readFile(venusPath);
+    directorContent = readFile(directorPath);
+    compositeContent = readFile(compositePath);
+
+    // Create mock resource manager that returns real file contents
+    mockResourceManager = {
+      resolve: async (ref) => {
+        console.log(`[Mock] Resolving: ${ref}`);
+
+        if (ref.includes('role://liutianchi')) {
+          return { success: true, content: liutianchiContent };
+        }
+        if (ref.includes('role://venus')) {
+          return { success: true, content: venusContent };
+        }
+        if (ref.includes('role://director')) {
+          return { success: true, content: directorContent };
+        }
+
+        // For other references (thought://, knowledge://, execution://),
+        // return a placeholder to avoid failures
+        if (ref.includes('thought://') || ref.includes('knowledge://') || ref.includes('execution://')) {
+          const resourceName = ref.split('://')[1];
+          return {
+            success: true,
+            content: `<${ref.split('://')[0]}>\n[${resourceName} content placeholder]\n</${ref.split('://')[0]}>`
+          };
+        }
+
+        return { success: false, error: { message: `Resource not found: ${ref}` } };
+      }
+    };
+  });
+
+  it('should load composite role and detect @!role:// references', () => {
+    // Skip if files not found
+    if (!compositeContent) {
+      console.log('Skipping: composite role not found');
+      return;
+    }
+
+    const personalityContent = parser.extractTagContent(compositeContent, 'personality');
+    const references = parser.extractReferences(personalityContent);
+
+    // Should find 3 role references
+    const roleRefs = references.filter(r => r.protocol === 'role');
+    expect(roleRefs.length).toBe(3);
+    expect(roleRefs.map(r => r.resource)).toContain('liutianchi');
+    expect(roleRefs.map(r => r.resource)).toContain('venus');
+    expect(roleRefs.map(r => r.resource)).toContain('director');
+  });
+
+  it('should recursively render role references with real content', async () => {
+    // Skip if files not found
+    if (!compositeContent) {
+      console.log('Skipping: composite role not found');
+      return;
+    }
+
+    const personalityContent = parser.extractTagContent(compositeContent, 'personality');
+    const tagSemantics = parser.parseTagContent(personalityContent, 'personality');
+
+    const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+    console.log('\n=== Rendered Content Preview ===');
+    console.log(result.substring(0, 2000));
+    console.log('...\n');
+
+    // Should contain all three role headers
+    expect(result).toContain('🎭 组合角色：liutianchi');
+    expect(result).toContain('🎭 组合角色：venus');
+    expect(result).toContain('🎭 组合角色：director');
+
+    // Should contain actual content from each role
+    expect(result).toContain('刘天池');
+    expect(result).toContain('中央戏剧学院');
+    expect(result).toContain('维纳斯');
+    expect(result).toContain('结构主义电影学');
+    expect(result).toContain('电影导演');
+    expect(result).toContain('视觉叙事');
+  });
+
+  it('should render nested references within roles', async () => {
+    // Skip if files not found
+    if (!compositeContent) {
+      console.log('Skipping: composite role not found');
+      return;
+    }
+
+    const personalityContent = parser.extractTagContent(compositeContent, 'personality');
+    const tagSemantics = parser.parseTagContent(personalityContent, 'personality');
+
+    const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+    // Should attempt to render nested thought:// and knowledge:// references
+    // (using our mock placeholders)
+    expect(result).toContain('思维模式') // From role rendering
+    expect(result).toContain('行为原则') // From role rendering
+  });
+
+  it('should output structured content suitable for AI consumption', async () => {
+    // Skip if files not found
+    if (!compositeContent) {
+      console.log('Skipping: composite role not found');
+      return;
+    }
+
+    const personalityContent = parser.extractTagContent(compositeContent, 'personality');
+    const tagSemantics = parser.parseTagContent(personalityContent, 'personality');
+
+    const result = await renderer.renderSemanticContent(tagSemantics, mockResourceManager);
+
+    // Check structure markers exist
+    expect(result).toMatch(/## 🎭 组合角色/);
+    expect(result).toMatch(/### 💭 思维模式/);
+
+    // Should be valid markdown
+    expect(result).not.toContain('<role>');
+    expect(result).not.toContain('</role>');
+    expect(result).not.toContain('@!role://'); // All references should be resolved
+  });
+});


### PR DESCRIPTION
- Add role protocol to semanticHeaders for proper rendering
- Implement recursive role content rendering via renderRoleContent()
- Add circular reference detection with visitedRoles Set
- Make logger optional for test environment compatibility

This enables composing multiple roles into one using @!role:// references:

```xml
<personality>
@!role://liutianchi
@!role://venus
@!role://director
</personality>
```

The system recursively loads each referenced role's full content, including their nested thought://, execution://, and knowledge:// references.

Tests included:
- Unit tests for role composition
- Integration tests with real role files
- E2E test validating complete workflow